### PR TITLE
User can see budget for any period

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.5.1'
 
 gem 'bootsnap', '>= 1.4.2', require: false
+gem 'jserializer'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.1'
 gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    jserializer (0.2.1)
     json (2.3.1)
     loofah (2.7.0)
       crass (~> 1.0.2)
@@ -195,6 +196,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   coveralls
   factory_bot_rails
+  jserializer
   pg (>= 0.18, < 2.0)
   pry-byebug
   pry-rails

--- a/README.md
+++ b/README.md
@@ -4,5 +4,11 @@
 ### /api/budgets#POST
 Required params: `amount:integer, start_date:date, end_date:date`
 
-Responds with `{ budget: { id, amount, start_date, end_date, created_at, updated_at } }, status 200` 
+Responds with `{ budget: { id, amount, start_date, end_date } }` 
 or `{ message: { *error message* } }, status 400`
+
+### /api/budgets#GET
+Required params: `requested_date:date string`
+
+Responds with `{ budget: { id, amount, start_date, end_date } }` 
+or `{ message: { *error message* } }, status 400/404`

--- a/app/controllers/api/budgets_controller.rb
+++ b/app/controllers/api/budgets_controller.rb
@@ -1,27 +1,44 @@
 class Api::BudgetsController < ApplicationController
-  def index
-    if params['containing_date'] == nil || params['containing_date'] == ""
-      render json: { message: "Please provide a date that's within the requested budget's time period, in the param 'containing_date'" }, 
-                     status: 400
-      return
-    end
+  before_action :validate_presence_of_containing_date, only: :index
 
-    budget = Budget.where("start_date < ? AND end_date > ?", params['containing_date'], params['containing_date'])[0]
+  def index
+    budget = Budget.where(
+      "start_date < ? AND end_date > ?", 
+      params['containing_date'], params['containing_date']
+    )[0]
 
     if budget != nil
       render json: { budget: budget }, status: 200
     else
-      render json: { message: 'No budget could be found for the requested period' }, status: 404
+      render json: { 
+         message: 'No budget could be found for the requested period' 
+      }, status: 404
     end 
   end
 
   def create 
-    budget = Budget.create(amount: params['amount'], start_date: params['start_date'], end_date: params['end_date'])
+    budget = Budget.create(create_params)
 
     if budget.persisted?
       render json: { budget: budget }, status: 200
     else
       render_error_message(budget.errors)
     end
+  end
+
+  private
+
+  def validate_presence_of_containing_date
+    if params['containing_date'] == nil || params['containing_date'] == ""
+      render json: { 
+         message: "Please provide a date that's within the requested budget's time period, in the param 'containing_date'" 
+      }, status: 400
+
+      return
+    end
+  end
+
+  def create_params 
+    params.permit(:amount, :start_date, :end_date)
   end
 end

--- a/app/controllers/api/budgets_controller.rb
+++ b/app/controllers/api/budgets_controller.rb
@@ -8,7 +8,7 @@ class Api::BudgetsController < ApplicationController
     )[0]
 
     if budget != nil
-      render json: { budget: budget }, status: 200
+      render json: SingleBudgetSerializer.new(budget)
     else
       case true
       when @requested_date == Date.today
@@ -27,7 +27,7 @@ class Api::BudgetsController < ApplicationController
     budget = Budget.create(create_params)
 
     if budget.persisted?
-      render json: { budget: budget }, status: 200
+      render json: SingleBudgetSerializer.new(budget)
     else
       render_error_message(budget.errors)
     end

--- a/app/controllers/api/budgets_controller.rb
+++ b/app/controllers/api/budgets_controller.rb
@@ -1,4 +1,20 @@
 class Api::BudgetsController < ApplicationController
+  def index
+    if params['containing_date'] == nil || params['containing_date'] == ""
+      render json: { message: "Please provide a date that's within the requested budget's time period, in the param 'containing_date'" }, 
+                     status: 400
+      return
+    end
+
+    budget = Budget.where("start_date < ? AND end_date > ?", params['containing_date'], params['containing_date'])[0]
+
+    if budget != nil
+      render json: { budget: budget }, status: 200
+    else
+      render json: { message: 'No budget could be found for the requested period' }, status: 404
+    end 
+  end
+
   def create 
     budget = Budget.create(amount: params['amount'], start_date: params['start_date'], end_date: params['end_date'])
 

--- a/app/serializers/single_budget_serializer.rb
+++ b/app/serializers/single_budget_serializer.rb
@@ -1,0 +1,4 @@
+class SingleBudgetSerializer < Jserializer::Base
+  root :budget
+  attributes :id, :amount, :start_date, :end_date
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   namespace :api do
-    resources :budgets, only: [:create]
+    resources :budgets, only: %i[index create]
   end
 end

--- a/spec/requests/api/budgets_create_spec.rb
+++ b/spec/requests/api/budgets_create_spec.rb
@@ -12,13 +12,9 @@ RSpec.describe 'POST /api/budgets', type: :request do
       expect(response).to have_http_status 200
     end
 
-    it 'responds with the Budget hash' do
-      expect(response_json['budget']).to have_key 'id'
-      expect(response_json['budget']).to have_key 'amount'
-      expect(response_json['budget']).to have_key 'start_date'
-      expect(response_json['budget']).to have_key 'end_date'
-      expect(response_json['budget']).to have_key 'created_at'
-      expect(response_json['budget']).to have_key 'updated_at'
+    it 'returns the created Budget' do
+      budget = Budget.last
+      expect(response_json['budget']['id']).to eq budget.id
     end
   end
 

--- a/spec/requests/api/budgets_index_spec.rb
+++ b/spec/requests/api/budgets_index_spec.rb
@@ -1,11 +1,9 @@
 RSpec.describe 'GET /api/budgets', type: :request do
-  let!(:budget) { create(:budget, start_date: Date.today - 15, end_date: Date.today + 15) }
+  let!(:budget) { create(:budget, start_date: Date.today + 15, end_date: Date.today + 45) }
 
   describe 'successfully with valid params' do
     before do
-      get "/api/budgets", params: {
-        containing_date: Date.today
-      }
+      get "/api/budgets", params: { requested_date: Date.today + 30}
     end
 
     it 'gives 200 status code response' do
@@ -18,7 +16,7 @@ RSpec.describe 'GET /api/budgets', type: :request do
   end
 
   describe 'unsuccessfully' do
-    describe 'if containing_date param is missing' do
+    describe 'if requested_date param is missing' do
       before do
         get "/api/budgets"
       end
@@ -29,23 +27,37 @@ RSpec.describe 'GET /api/budgets', type: :request do
       
       it 'gives error message' do
         expect(response_json['message'])
-        .to eq "Please provide a date that's within the requested budget's time period, in the param 'containing_date'"
+        .to eq "Please provide a date that's within the time period you are looking for."
       end
     end
     
     describe "if the requested date can't be found within any budget period" do
-      before do
-        get "/api/budgets", params: {
-          containing_date: Date.today.next_year
-        }
-      end
-        
       it 'gives 404 response' do
+        get "/api/budgets", params: { requested_date: Date.today.next_year }
         expect(response).to have_http_status 404
       end
       
-      it 'gives error message' do
-        expect(response_json['message']).to eq 'No budget could be found for the requested period'
+      describe 'gives meaningful message' do
+        it 'for past dates' do
+          get "/api/budgets", params: { requested_date: Date.today.last_year }
+          
+          expect(response_json['message'])
+          .to eq "You didn't have any budget set for #{Date.today.last_year.strftime("%d %b, %Y")}"
+        end
+
+        it "for today's date" do
+          get "/api/budgets", params: { requested_date: Date.today }
+
+          expect(response_json['message'])
+          .to eq "You don't have any budget set currently"
+        end
+        
+        it 'for upcoming dates' do
+          get "/api/budgets", params: { requested_date: Date.today.next_year }
+
+          expect(response_json['message'])
+          .to eq "You don't have any budget set for #{Date.today.next_year.strftime("%d %b, %Y")}"
+        end
       end
     end
   end

--- a/spec/requests/api/budgets_index_spec.rb
+++ b/spec/requests/api/budgets_index_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'GET /api/budgets', type: :request do
     end
 
     it 'returns budget for the requested period' do
-      expect(response_json['budget']).to eq budget
+      expect(response_json['budget']['id']).to eq budget.id
     end
   end
 
@@ -28,14 +28,16 @@ RSpec.describe 'GET /api/budgets', type: :request do
       end
       
       it 'gives error message' do
-        expect(response_json['error'])
+        expect(response_json['message'])
         .to eq "Please provide a date that's within the requested budget's time period, in the param 'containing_date'"
       end
     end
     
     describe "if the requested date can't be found within any budget period" do
       before do
-        get "/api/budgets"
+        get "/api/budgets", params: {
+          containing_date: Date.today.next_year
+        }
       end
         
       it 'gives 404 response' do
@@ -43,7 +45,7 @@ RSpec.describe 'GET /api/budgets', type: :request do
       end
       
       it 'gives error message' do
-        expect(response_json['error']).to eq "No budget could be found for the requested period"
+        expect(response_json['message']).to eq 'No budget could be found for the requested period'
       end
     end
   end

--- a/spec/requests/api/budgets_index_spec.rb
+++ b/spec/requests/api/budgets_index_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe 'GET /api/budgets', type: :request do
+  let!(:budget) { create(:budget, start_date: Date.today - 15, end_date: Date.today + 15) }
+
+  describe 'successfully with valid params' do
+    before do
+      get "/api/budgets", params: {
+        containing_date: Date.today
+      }
+    end
+
+    it 'gives 200 status code response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'returns budget for the requested period' do
+      expect(response_json['budget']).to eq budget
+    end
+  end
+
+  describe 'unsuccessfully' do
+    describe 'if containing_date param is missing' do
+      before do
+        get "/api/budgets"
+      end
+      
+      it 'gives 400 response' do
+        expect(response).to have_http_status 400
+      end
+      
+      it 'gives error message' do
+        expect(response_json['error'])
+        .to eq "Please provide a date that's within the requested budget's time period, in the param 'containing_date'"
+      end
+    end
+    
+    describe "if the requested date can't be found within any budget period" do
+      before do
+        get "/api/budgets"
+      end
+        
+      it 'gives 404 response' do
+        expect(response).to have_http_status 404
+      end
+      
+      it 'gives error message' do
+        expect(response_json['error']).to eq "No budget could be found for the requested period"
+      end
+    end
+  end
+end

--- a/spec/serializers/single_budget_serializer_spec.rb
+++ b/spec/serializers/single_budget_serializer_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe SingleBudgetSerializer, type: :serializer do
+  let!(:budget) { create(:budget) }
+
+  before do
+    serializer = SingleBudgetSerializer.new(budget)
+    @hash = serializer.as_json
+  end
+
+  it 'has root "budget"' do
+    expect(@hash).to have_key :budget
+  end
+
+  it 'has keys id, amount, start_date and end_date' do
+    expected_keys = %i[id amount start_date end_date]
+    expect(@hash[:budget].keys).to match expected_keys
+  end
+end


### PR DESCRIPTION
[Story on Pivotal Tracker](https://www.pivotaltracker.com/story/show/174879812)

## Feature
Any budget can be retrieved by providing a date that's within the desired budget's time period, in a GET request to /api/budgets.

## Additions
### Gems
[Jserializer](https://github.com/distil/jserializer)

### BudgetsController#index
Requires param `requested_date:date string`. Queries the database for the budget that contains the requested date and returns it. If no budget could be found, it returns an informative message: "You didn't have any active budget for 10 Sep, 2020"

### SingleBudgetSerializer
Controls the json object that contains the budget response. Has its own spec rather than testing the response in the request specs.